### PR TITLE
feat: Allow case-insensitive registration number

### DIFF
--- a/internal/userAuth/repository.go
+++ b/internal/userAuth/repository.go
@@ -128,6 +128,9 @@ func (repo UserAuthRepo) Register(regno, username, pass string) (*db.User, error
 		return nil, fmt.Errorf("all fields are required")
 	}
 
+	// Convert the input to lowercase BEFORE validation
+	regno = strings.ToLower(regno)
+
 	re := regexp.MustCompile(`^\d{2}[a-z]{3}\d{4}$`)
 
 	if !re.MatchString(regno) {


### PR DESCRIPTION
Hello,

I noticed that the registration fails if the registration number contains uppercase letters (e.g., 22BCE2136) but works for lowercase (22bce2136).

A simple fix for this would be to convert the regno to lowercase before validation in the Register function.

Suggested change:
Add regno = strings.ToLower(regno) right after the initial check for empty fields.

This would improve user experience and ensure data consistency. Thanks!

